### PR TITLE
Potential fix for code scanning alert no. 100: Type confusion through parameter tampering

### DIFF
--- a/routes/resources.js
+++ b/routes/resources.js
@@ -57,12 +57,23 @@ router.get('/', async (req, res) => {
         const whereClause = {};
         
         if (type) {
-            // Tratar múltiplos tipos separados por vírgula
-            if (type.includes(',')) {
-                const types = type.split(',').map(t => t.trim());
-                whereClause.type = { [Op.in]: types };
-            } else {
-                whereClause.type = type;
+            // Normalizar "type" para string para evitar confusão de tipos (array vs string)
+            let typeStr = null;
+            if (typeof type === 'string') {
+                typeStr = type;
+            } else if (Array.isArray(type)) {
+                // Junta múltiplos parâmetros "type" em uma única string, compatível com a lógica existente
+                typeStr = type.join(',');
+            }
+
+            if (typeStr) {
+                // Tratar múltiplos tipos separados por vírgula
+                if (typeStr.includes(',')) {
+                    const types = typeStr.split(',').map(t => t.trim());
+                    whereClause.type = { [Op.in]: types };
+                } else {
+                    whereClause.type = typeStr;
+                }
             }
         }
         


### PR DESCRIPTION
Potential fix for [https://github.com/Abnerlucasm/neo_utilitario/security/code-scanning/100](https://github.com/Abnerlucasm/neo_utilitario/security/code-scanning/100)

In general, to fix this class of issues you must validate the runtime type of any user-controlled value before treating it as a string. For query parameters, that means: if the value is not exactly a string (for example, it is an array or object), either reject the request as invalid or normalize it deterministically (e.g., take the first element and join with commas explicitly) and then apply sanitization or business logic.

For this specific `routes/resources.js` snippet, the minimal change that preserves existing behavior is to safely normalize `type` into a string before using `.includes` and `.split`. One straightforward approach:

- Compute a `typeStr` variable that is guaranteed to be a string:
  - If `type` is a string, use it as-is.
  - If `type` is an array, join its elements with commas into a single string (so existing comma-based logic still works in a predictable way).
  - If `type` is anything else (`undefined`, object), treat it as absent.
- Use `typeStr` instead of `type` for `.includes` and `.split` and for assigning `whereClause.type` in the single-type branch.

Concretely:

- Right after line 59 `if (type) {`, introduce a `let typeStr = null;` and set it based on the runtime type of `type` using `typeof` and `Array.isArray`.
- Change the subsequent logic (lines 61–66) to:
  - Check `if (typeStr.includes(','))` and `typeStr.split(',')`.
  - In the else branch, assign `whereClause.type = typeStr;`.

This keeps the intended behavior (supporting comma-separated types) but prevents type confusion and runtime errors when `type` is an array.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
